### PR TITLE
Introduction of ALARO tests in DAVAI test branch

### DIFF
--- a/conf/atos_bologna.ini
+++ b/conf/atos_bologna.ini
@@ -273,7 +273,12 @@ rundate             = date(2020081800)
 [forecast-alaro-cz2300]
 rundate             = date(2020081800)
 
-[forecast-alaro-antwrp1300]
+[forecast-alaro0-antwrp1300]
+alaro_version       = 0
+rundate             = date(2020081800)
+
+[forecast-alaro1-antwrp1300]
+alaro_version       = 1
 rundate             = date(2020081800)
 
 # ======================================================================== JOBS

--- a/conf/atos_bologna.ini
+++ b/conf/atos_bologna.ini
@@ -15,19 +15,21 @@ ref_namespace       = vortex.multi.fr
 IAL_git_ref         = <commit or branch or tag>
 IAL_repository      = <path to your IAL repository>
 # static resources : uenv/genv
-davaienv            = uenv:cy48t3.davai_specials.02_clean@davai
-appenv_global       = uenv:cy48t3.arpege@4dvarfr.01_cep@davai
-appenv_lam          = uenv:cy48t1.LAM@davai-preT2.02_cep@davai
-appenv_fullpos_partners = uenv:cy48t3.fullpos@partners.01_cep@davai
+davaienv            = uenv:cy48t3.davai_specials.03-alaro@cv9
+appenv_global       = uenv:cy48t3.arpege@4dvarfr.01_cep-gmirror@davai
+appenv_lam          = uenv:cy48t1.LAM@davai-preT2.02_cep-gmirror@davai
+appenv_fullpos_partners = uenv:cy48t3.fullpos@partners.01_cep-gmirror@davai
 appenv_clim         = uenv:cy48t1_clim-op0.03_empty@rm9
 commonenv           = ${appenv_global}
 # pseudo-dataflow resources : shelves
 input_shelf_global  = shelf_cy48t3_global.01@davai
 input_shelf_LAM     = shelf_cy48t1_LAM.01@davai
+input_shelf_ALARO   = shelf_cy48t1_ALARO.01@davai
 shelves_vapp        = davai
 shelves_vconf       = shelves
 shelves2bucket      = False
 # Davai options
+billing_account     = bedb
 comment             = What is being tested
 usecase             = NRV
 davai_server        = http://www.umr-cnrm.fr/davai
@@ -79,6 +81,15 @@ input_shelf         = &{input_shelf_lam}
 fcst_term           = 12
 expertise_term      = 12
 coupling_frequency  = 1
+
+[alaro]
+model               = alaro
+LAM                 = True
+appenv              = &{appenv_lam}
+input_shelf         = &{input_shelf_alaro}
+fcst_term           = 12
+expertise_term      = 12
+coupling_frequency  = 3
 
 [arpege]
 model               = arpege
@@ -174,6 +185,14 @@ timestep            = 600
 geometry            = geometry(corsica2500)
 timestep            = 60
 
+[cz2300]
+geometry            = geometry(cz2300)
+timestep            = 90
+
+[antwrp1300]
+geometry            = geometry(antwrp1300)
+timestep            = 60
+
 [global21]
 geometry            = geometry(global21)
 timestep            = 3600
@@ -249,6 +268,12 @@ rundate             = date(2004101512)
 rundate             = date(2020081800)
 
 [forecast-arome-corsica2500]
+rundate             = date(2020081800)
+
+[forecast-alaro-cz2300]
+rundate             = date(2020081800)
+
+[forecast-alaro-antwrp1300]
 rundate             = date(2020081800)
 
 # ======================================================================== JOBS

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -52,7 +52,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
             #-------------------------------------------------------------------------------
 
         # 1.1.0/ Reference resources, to be compared to:
-        if False and  ( 'early-fetch' in self.steps or 'fetch' in self.steps ):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
             self._wrapped_input(**self._reference_continuity_expertise())
             self._wrapped_input(**self._reference_continuity_listing())
             #-------------------------------------------------------------------------------
@@ -69,7 +69,8 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 vconf          = self.conf.ref_vconf,
             )
             #-------------------------------------------------------------------------------
-            self._wrapped_input(
+            if False:
+              self._wrapped_input(
                 role           = 'Reference',  # SurfState
                 block          = self.output_block(),
                 experiment     = self.conf.ref_xpid,
@@ -81,7 +82,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 nativefmt      = 'fa',
                 term           = self.conf.expertise_term,
                 vconf          = self.conf.ref_vconf,
-            )
+              )
             #-------------------------------------------------------------------------------
 
         # 1.1.1/ Static Resources:
@@ -159,7 +160,8 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                 intent         = 'inout',
                 kind           = 'namelist',
                 local          = 'fort.4',
-                source         = 'model/[model]/fcst.alaro.nam',
+                alaro_version  = self.conf.alaro_version,
+                source         = 'model/[model]/fcst.alaro[alaro_version].nam',
             )
             #-------------------------------------------------------------------------------
 

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -1,0 +1,336 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import print_function, absolute_import, unicode_literals, division
+
+from footprints import FPDict
+from footprints.util import rangex
+
+import vortex
+from vortex import toolbox
+from vortex.layout.nodes import Task, Family, Driver
+from common.util.hooks import update_namelist
+import davai
+
+from davai_taskutil.mixins import DavaiIALTaskMixin, IncludesTaskMixin
+
+
+class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
+
+    @property
+    def experts(self):
+        """Redefinition as property because of runtime/conf-determined values."""
+        return [FPDict({'kind':'norms', 'plot_spectral':True, 'hide_equal_norms':self.conf.hide_equal_norms}),
+                FPDict({'kind':'fields_in_file'})
+                ] + davai.util.default_experts()
+
+    def _flow_input_pgd_block(self):
+        """Block of PGD in case of a PPF flow-chained job."""
+        return '-'.join([self.conf.prefix,
+                         'pgd',
+                         self.conf.model,
+                         self.conf.geometry.tag])
+
+    def _flow_input_surf_ic_block(self):
+        """Block of surf IC in case of a PPF flow-chained job."""
+        return '-'.join([self.conf.prefix,
+                         'prep',
+                         self.conf.model,
+                         self.conf.geometry.tag])
+
+    def output_block(self):
+        return '-'.join([self.conf.prefix,
+                         self.tag])
+
+    def process(self):
+        self._wrapped_init()
+        self._notify_start_inputs()
+
+        # 0./ Promises
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            self._wrapped_promise(**self._promised_listing())
+            self._wrapped_promise(**self._promised_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 1.1.0/ Reference resources, to be compared to:
+        if False and  ( 'early-fetch' in self.steps or 'fetch' in self.steps ):
+            self._wrapped_input(**self._reference_continuity_expertise())
+            self._wrapped_input(**self._reference_continuity_listing())
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # ModelState
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ref.ICMSHFCST+[term:fmthm]',
+                nativefmt      = 'fa',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Reference',  # SurfState
+                block          = self.output_block(),
+                experiment     = self.conf.ref_xpid,
+                fatal          = False,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ref.ICMSHFCST+[term:fmthm].sfx',
+                model          = 'surfex',
+                nativefmt      = 'fa',
+                term           = self.conf.expertise_term,
+                vconf          = self.conf.ref_vconf,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.1/ Static Resources:
+        if False and ( 'early-fetch' in self.steps or 'fetch' in self.steps ) :
+            self._load_usual_tools()  # LFI tools, ecCodes defs, ...
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RrtmConst',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rrtm',
+                local          = 'rrtm.const.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'RtCoef',
+                format         = 'unknown',
+                genv           = self.conf.commonenv,
+                kind           = 'rtcoef',
+                local          = 'var.sat.misc_rtcoef.01.tgz',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'CoverParams',
+                format         = 'foo',
+                genv           = self.conf.commonenv,
+                kind           = 'coverparams',
+                local          = 'ecoclimap_covers_param.tgz',
+                source         = 'ecoclimap',
+            )
+            #-------------------------------------------------------------------------------
+            if self.conf.pgd_source == 'static':
+                self._wrapped_input(
+                    role           = 'ClimPGD',
+                    format         = 'fa',
+                    genv           = self.conf.appenv,
+                    gvar           = 'pgd_fa_[geometry::tag]',
+                    kind           = 'pgdfa',
+                    local          = 'Const.Clim.sfx',
+                )
+                # else: 2.1
+            #-------------------------------------------------------------------------------
+            tbclim = self._wrapped_input(
+                role           = 'Clim',
+                format         = 'fa',
+                genv           = self.conf.appenv,
+                kind           = 'clim_model',
+                local          = 'Const.Clim',
+                month          = self.conf.rundate,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.2/ Static Resources (namelist(s) & config):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            # deactivate FPinline & DDH, activate spnorms:
+            tboptions = self._wrapped_input(
+                role           = 'Namelist Deltas to add/remove options',
+                binary         = 'arpifs',
+                component      = 'noFPinline.nam,noDDH.nam,spnorms.nam',
+                format         = 'ascii',
+                genv           = self.conf.davaienv,
+                intent         = 'in',
+                kind           = 'namelist',
+                local          = '[component]',
+                source         = 'model/options_delta/[component]',
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Namelist',
+                binary         = 'arpifs',
+                format         = 'ascii',
+                genv           = self.conf.davaienv,
+                hook_options   = (update_namelist, tboptions),
+                intent         = 'inout',
+                kind           = 'namelist',
+                local          = 'fort.4',
+                source         = 'model/[model]/fcst.alaro.nam',
+            )
+            #-------------------------------------------------------------------------------
+
+        # 1.1.3/ Static Resources (executables):
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            tbx = self.flow_executable()
+            #-------------------------------------------------------------------------------
+
+        # 1.2/ Flow Resources (initial): theoretically flow-resources, but statically stored in input_shelf
+        if 'early-fetch' in self.steps or 'fetch' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'Atmospheric Initial Conditions',
+                block          = 'coupling',
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                format         = '[nativefmt]',
+                intent         = 'inout',
+                kind           = 'boundary',
+                local          = 'ICMSHFCSTINIT',
+                nativefmt      = 'fa',
+                source_app     = 'arpege',
+                source_conf    = '4dvarfr',
+                term           = 0,
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            if False and self.conf.surf_ic_source == 'static':
+                self._wrapped_input(
+                    role           = 'Surface Initial conditions',
+                    block          = 'surfan',
+                    date           = self.conf.rundate,
+                    experiment     = self.conf.input_shelf,
+                    filling        = 'surf',
+                    format         = '[nativefmt]',
+                    kind           = 'analysis',
+                    local          = 'ICMSHFCSTINIT.sfx',
+                    model          = 'surfex',
+                    nativefmt      = 'fa',
+                    vapp           = self.conf.shelves_vapp,
+                    vconf          = self.conf.shelves_vconf,
+                )
+                # else: 2.1
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'BoundaryConditions',  # Initial
+                block          = 'coupling',
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                format         = '[nativefmt]',
+                intent         = 'inout',
+                kind           = 'boundary',
+                local          = 'CPLIN+START',
+                nativefmt      = 'fa',
+                source_app     = 'arpege',
+                source_conf    = '4dvarfr',
+                term           = 0,
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+            self._wrapped_input(
+                role           = 'BoundaryConditions',
+                block          = 'coupling',
+                date           = self.conf.rundate,
+                experiment     = self.conf.input_shelf,
+                format         = '[nativefmt]',
+                intent         = 'inout',
+                kind           = 'boundary',
+                local          = 'CPLIN+[term::fmthm]',
+                nativefmt      = 'fa',
+                source_app     = 'arpege',
+                source_conf    = '4dvarfr',
+                term           = rangex(self.conf.coupling_frequency, self.conf.fcst_term,
+                                        self.conf.coupling_frequency),
+                vapp           = self.conf.shelves_vapp,
+                vconf          = self.conf.shelves_vconf,
+            )
+            #-------------------------------------------------------------------------------
+
+        # 2.1/ Flow Resources: produced by another task of the same job
+        if 'fetch' in self.steps:
+            if False and self.conf.pgd_source == 'flow':
+                self._wrapped_input(
+                    role           = 'PGD',
+                    block          = self._flow_input_pgd_block(),
+                    experiment     = self.conf.xpid,
+                    format         = 'fa',
+                    kind           = 'pgdfa',
+                    local          = 'Const.Clim.sfx',
+                )
+                # else: 1.1.1
+            #-------------------------------------------------------------------------------
+            if False and self.conf.surf_ic_source == 'flow':
+                self._wrapped_input(
+                    role           = 'Surface Initial conditions',
+                    block          = self._flow_input_surf_ic_block(),
+                    date           = self.conf.rundate,
+                    experiment     = self.conf.xpid,
+                    format         = '[nativefmt]',
+                    filling        = 'surf',
+                    kind           = 'ic',
+                    local          = 'ICMSHFCSTINIT.sfx',
+                    model          = 'surfex',
+                    nativefmt      = 'fa',
+                )
+                # else: 1.2
+            #-------------------------------------------------------------------------------
+
+        # 2.2/ Compute step
+        if 'compute' in self.steps:
+            self._notify_start_compute()
+            self.sh.title('Toolbox algo = tbalgo')
+            tbalgo = toolbox.algo(
+                crash_witness  = True,
+                drhookprof     = self.conf.drhook_profiling,
+                engine         = 'parallel',
+                kind           = 'lamfc',
+                fcterm         = self.conf.fcst_term,
+                fcunit         = 'h',
+                timestep       = self.conf.timestep,
+            )
+            print(self.ticket.prompt, 'tbalgo =', tbalgo)
+            print()
+            self.component_runner(tbalgo, tbx)
+            #-------------------------------------------------------------------------------
+            self.run_expertise()
+            #-------------------------------------------------------------------------------
+
+        # 2.3/ Flow Resources: produced by this task and possibly used by a subsequent flow-dependant task
+        if 'backup' in self.steps:
+            #-------------------------------------------------------------------------------
+            self._wrapped_output(
+                role           = 'ModelState',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ICMSHFCST+{glob:term:\d+(?::\d+)?}',
+                namespace      = self.REF_OUTPUT,
+                nativefmt      = 'fa',
+                term           = '[glob:term]',
+            )
+            #-------------------------------------------------------------------------------
+            if False:
+              self._wrapped_output(
+                role           = 'SurfState',
+                block          = self.output_block(),
+                experiment     = self.conf.xpid,
+                format         = '[nativefmt]',
+                kind           = 'historic',
+                local          = 'ICMSHFCST+{glob:term:\d+(?::\d+)?}.sfx',
+                model          = 'surfex',
+                namespace      = self.REF_OUTPUT,
+                nativefmt      = 'fa',
+                term           = '[glob:term]',
+              )
+            #-------------------------------------------------------------------------------
+
+        # 3.0.1/ Davai expertise:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_expertise())
+            self._wrapped_output(**self._output_comparison_expertise())
+            #-------------------------------------------------------------------------------
+
+        # 3.0.2/ Other output resources of possible interest:
+        if 'late-backup' in self.steps or 'backup' in self.steps:
+            self._wrapped_output(**self._output_listing())
+            self._wrapped_output(**self._output_stdeo())
+            self._wrapped_output(**self._output_drhook_profiles())
+            #-------------------------------------------------------------------------------
+

--- a/src/tasks/forecasts/standalone_forecasts.py
+++ b/src/tasks/forecasts/standalone_forecasts.py
@@ -39,11 +39,12 @@ def setup(t, **kw):
                     ], **kw),
                Family(tag='alaro', ticket=t, on_error='delayed_fail', nodes=[
                     Family(tag='antwrp1300', ticket=t, nodes=[
-                        StandaloneAlaroForecast(tag='forecast-alaro-antwrp1300', ticket=t, **kw),
+                        StandaloneAlaroForecast(tag='forecast-alaro0-antwrp1300', ticket=t, **kw),
+                        StandaloneAlaroForecast(tag='forecast-alaro1-antwrp1300', ticket=t, **kw),
                         ], **kw),
-                    Family(tag='cz2300', ticket=t, nodes=[
-                        StandaloneAlaroForecast(tag='forecast-alaro-cz2300', ticket=t, **kw),
-                        ], **kw),
+#                    Family(tag='cz2300', ticket=t, nodes=[
+#                        StandaloneAlaroForecast(tag='forecast-alaro-cz2300', ticket=t, **kw),
+#                        ], **kw),
                     ], **kw),
                 ], **kw),
         ],

--- a/src/tasks/forecasts/standalone_forecasts.py
+++ b/src/tasks/forecasts/standalone_forecasts.py
@@ -13,6 +13,7 @@ import davai
 from .standalone.ifs import StandaloneIFSForecast
 from .standalone.arpege import StandaloneArpegeForecast
 from .standalone.arome import StandaloneAromeForecast
+from .standalone.alaro import StandaloneAlaroForecast
 
 
 def setup(t, **kw):
@@ -36,7 +37,15 @@ def setup(t, **kw):
                         StandaloneAromeForecast(tag='forecast-arome-corsica2500', ticket=t, **kw),
                         ], **kw),
                     ], **kw),
-            ], **kw),
+               Family(tag='alaro', ticket=t, on_error='delayed_fail', nodes=[
+                    Family(tag='antwrp1300', ticket=t, nodes=[
+                        StandaloneAlaroForecast(tag='forecast-alaro-antwrp1300', ticket=t, **kw),
+                        ], **kw),
+                    Family(tag='cz2300', ticket=t, nodes=[
+                        StandaloneAlaroForecast(tag='forecast-alaro-cz2300', ticket=t, **kw),
+                        ], **kw),
+                    ], **kw),
+                ], **kw),
         ],
     )
 


### PR DESCRIPTION
3 cases:

alaro0 on small domain (antwrp1300) -- standalone forecast
alaro1 on small domain (antwrp1300) -- standalone forecast
alaro1 on large domain (cz2300) -- (disabled for now in standalone_forecasts.py) should probably go into canonical forecast

Some references to my personal uget/uenv/shelves content should be removed.

The tests cases were only introduced into atos_bologna.ini; should also be put in belenos.ini. Even better, a mechanism could be devised to combine  a machine-specific part and a common part for the ini files.