### PR TITLE
Fixed ALARO+SFX test for cy49t2

### DIFF
--- a/conf/atos_bologna.ini
+++ b/conf/atos_bologna.ini
@@ -99,8 +99,8 @@ expertise_term      = 24
 model               = alaro
 LAM                 = True
 appenv              = &{appenv_lam}
-fcst_term           = 12
-expertise_term      = 12
+fcst_term           = 6
+expertise_term      = 6
 coupling_frequency  = 3
 
 [4dvar6h]
@@ -283,9 +283,9 @@ rundate             = date(2020081800)
 alaro_version       = 1
 rundate             = date(2020081800)
 
-[forecast-alaro1_sfx-chmh2325]
+[forecast-alaro1_sfx-antwrp1300]
 alaro_version       = 1_sfx
-rundate             = date(2021022000)
+rundate             = date(2020081800)
 
 # ======================================================================== JOBS
 

--- a/src/tasks/forecasts/standalone/alaro.py
+++ b/src/tasks/forecasts/standalone/alaro.py
@@ -122,7 +122,7 @@ class StandaloneAlaroForecast(Task, DavaiIALTaskMixin, IncludesTaskMixin):
                     self._wrapped_input(
                         role           = 'ClimPGD',
                         format         = 'fa',
-                        genv           = self.conf.davaienv,
+                        genv           = self.conf.appenv,
                         gvar           = 'pgd_fa_[geometry::tag]',
                         kind           = 'pgdfa',
                         local          = 'Const.Clim.sfx',

--- a/src/tasks/forecasts/standalone_forecasts.py
+++ b/src/tasks/forecasts/standalone_forecasts.py
@@ -42,11 +42,8 @@ def setup(t, **kw):
                     Family(tag='antwrp1300', ticket=t, nodes=[
                         StandaloneAlaroForecast(tag='forecast-alaro0-antwrp1300', ticket=t, on_error='delayed_fail', **kw),
                         StandaloneAlaroForecast(tag='forecast-alaro1-antwrp1300', ticket=t, on_error='delayed_fail', **kw),
+                        StandaloneAlaroForecast(tag='forecast-alaro1_sfx-antwrp1300', ticket=t, on_error='delayed_fail', **kw),
                         ], **kw),
-                    # FIXME 49T2:
-                    #Family(tag='chmh2325', ticket=t, nodes=[
-                    #    StandaloneAlaroForecast(tag='forecast-alaro1_sfx-chmh2325', ticket=t, **kw),
-                    #    ], **kw),
                     ], **kw),
                 ], **kw),
         ],


### PR DESCRIPTION
Regenerated PGD file and initial surfex file for new surfex version in cy49t2.

Also took the opportunity to change the domain and date for this test to the same domain/date as for the other standalone ALARO tests.

PGD file on atos-bologna:/home/cv9/.vortexrc/hack/uget/davai/data/pgd.antwrp-01km30.fa.01
Initial atmospheric files on atos-bologna:/scratch/cv9/mtool/cache/vortex/davai/shelves/shelf_cy49t1.02@davai/20200818T0000A/coupling/
Initial surface file on atos-bologna:/scratch/cv9/mtool/cache/vortex/davai/shelves/shelf_cy49t1.02@davai/20200818T0000A/surfan/

