### PR TITLE
Create temporary changes and new tag for developers on ATOS -- CY49T2

### DIFF
--- a/conf/NRV.yaml
+++ b/conf/NRV.yaml
@@ -14,7 +14,8 @@ mixs:
 
 objects:
     - Bmat_arpege  # Construction and reading of a B-matrix using an ensemble, EnVar unit tests
-    - ModelTL_arpege # TL model, adjoint test
+# OOPS based expert (OOPSmodelADExpert) can't be found on ATOS - no sense to test
+#    - ModelTL_arpege # TL model, adjoint test
 
 fullpos:
     - Fp_lbc  # Fp_lbc = Fullpos creation of LBC files

--- a/conf/atos_bologna.ini
+++ b/conf/atos_bologna.ini
@@ -72,6 +72,8 @@ compilation_flavours = list(OMPIIFC2302.x,OMPIIFC2302SP.x)
 
 [default_compilation_flavour]
 compilation_flavour = OMPIIFC2302.x
+# Add new list to create a loop for standalone alaro forecasts at ATOS
+flavours = list(OMPIIFC2302.x)
 
 [arome]
 model               = arome
@@ -164,7 +166,9 @@ bathymetry_source   = etopo1
 bathymetry_geometry = global1min
 
 [lam_geometries]
-geometrys           = geometry(list(sps2500,nps2500,sm2500,nm2500,slcc2500,nlcc2500))
+geometrys           = geometry(list(nps2500,sm2500,nm2500,slcc2500,nlcc2500))
+# take out sps2500 because it crashes in pgd part of task on ATOS
+#geometrys           = geometry(list(sps2500,nps2500,sm2500,nm2500,slcc2500,nlcc2500))
 
 [gauss_grids]
 geometrys           = geometry(list(global63,global63c22))

--- a/src/tasks/forecasts/standalone_forecasts.py
+++ b/src/tasks/forecasts/standalone_forecasts.py
@@ -38,6 +38,12 @@ def setup(t, **kw):
                         StandaloneAromeForecast(tag='forecast-arome-corsica2500', ticket=t, **kw),
                         ], **kw),
                     ], **kw),
+                ], **kw),
+# All alaro forecasts crash on ATOS in single precision (no need to run) - but still run double precision
+        LoopFamily(tag='default_compilation_flavour', ticket=t,
+            loopconf='flavours',
+            loopsuffix='.{}',
+            nodes=[
                 Family(tag='alaro', ticket=t, on_error='delayed_fail', nodes=[
                     Family(tag='antwrp1300', ticket=t, nodes=[
                         StandaloneAlaroForecast(tag='forecast-alaro0-antwrp1300', on_error='delayed_fail', ticket=t, **kw),
@@ -47,4 +53,3 @@ def setup(t, **kw):
                 ], **kw),
         ],
     )
-

--- a/src/tasks/fullpos/Fp_lbc.py
+++ b/src/tasks/fullpos/Fp_lbc.py
@@ -15,9 +15,10 @@ from .ifs_lbc import IFS_LBCbyFullpos
 def setup(t, **kw):
     return Driver(tag='drv', ticket=t, options=kw, nodes=[
         Family(tag='default_compilation_flavour', ticket=t, nodes=[
-                Family(tag='ifs', ticket=t, on_error='delayed_fail', nodes=[
-                    IFS_LBCbyFullpos(tag='fp_lbc-ifs', ticket=t, **kw),
-                    ], **kw),
+# Fullpos creation of LBCs is failing at ATOS - no need to run there
+#                Family(tag='ifs', ticket=t, on_error='delayed_fail', nodes=[
+#                    IFS_LBCbyFullpos(tag='fp_lbc-ifs', ticket=t, **kw),
+#                    ], **kw),
                 Family(tag='arpege', ticket=t, on_error='delayed_fail', nodes=[
                     ArpegeLBCbyFullpos(tag='fp_lbc-arpege', ticket=t, **kw),
                     ], **kw),

--- a/src/tasks/mixs/PF.py
+++ b/src/tasks/mixs/PF.py
@@ -25,7 +25,8 @@ def setup(t, **kw):
             Family(tag='arpege', ticket=t, on_error='delayed_fail', nodes=[
                 Family(tag='globaltst149c24', ticket=t, nodes=[
                     Prep(tag='prep-arpege-globaltst149c24', ticket=t, **kw),
-                    StandaloneArpegeForecast(tag='forecast-arpege-globaltst149c24', ticket=t, **kw),
+# Standalone Arpege forecast crashes after prep at ATOS - same as PPF.py
+#                    StandaloneArpegeForecast(tag='forecast-arpege-globaltst149c24', ticket=t, **kw),
                     ], **kw),
                 ], **kw),
             ], **kw),

--- a/src/tasks/mixs/PPF.py
+++ b/src/tasks/mixs/PPF.py
@@ -32,10 +32,10 @@ def setup(t, **kw):
                         PGD(tag='pgd-arpege-globaltst149c24', ticket=t, **kw),
                         ], **kw),
                     Prep(tag='prep-arpege-globaltst149c24', ticket=t, **kw),
-                    StandaloneArpegeForecast(tag='forecast-arpege-globaltst149c24', ticket=t, **kw),
+# Standalone Arpege forecast crashes after prep at ATOS - same as PF.py
+#                    StandaloneArpegeForecast(tag='forecast-arpege-globaltst149c24', ticket=t, **kw),
                     ], **kw),
                 ], **kw),
             ], **kw),
         ],
     )
-

--- a/src/tasks/objects/Bmat_arpege.py
+++ b/src/tasks/objects/Bmat_arpege.py
@@ -18,15 +18,16 @@ def setup(t, **kw):
                 Family(tag='default_compilation_flavour', ticket=t, nodes=[
                     BmatSimple(tag='BmatSp', ticket=t, **kw),
                     BmatFlowDependent(tag='BmatWv', ticket=t, **kw),
-                    EnVarAdjoint(tag='EnVarAdjoint', ticket=t, **kw),
-                    LoopFamily(tag='ensread', ticket=t,
-                        loopconf='mpireads',
-                        loopsuffix='-mpi{}',
-                        nodes=[
-                        Family('EnsRead', ticket=t, on_error='delayed_fail', nodes=[
-                            EnsembleRead(tag='EnsembleRead', ticket=t, **kw),
-                            ], **kw),
-                        ], **kw),
+# Bmat_arpege - OOPS based experts (OOPSVariancesExpert or OOPSJoADExpert) can't be found at ATOS - no sense to run
+#                    EnVarAdjoint(tag='EnVarAdjoint', ticket=t, **kw),
+#                    LoopFamily(tag='ensread', ticket=t,
+#                        loopconf='mpireads',
+#                        loopsuffix='-mpi{}',
+#                        nodes=[
+#                        Family('EnsRead', ticket=t, on_error='delayed_fail', nodes=[
+#                            EnsembleRead(tag='EnsembleRead', ticket=t, **kw),
+#                            ], **kw),
+#                        ], **kw),
                     ], **kw),
                 ], **kw),
             ], **kw),


### PR DESCRIPTION
This removes the current tasks from the NRV tests that crash and/or have an expertise missing on ATOS. The recommendation is to make a temporary tag to allow IAL developers to focus more effectively on the working cases.